### PR TITLE
feat: 絵文字の保存先を変更

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -1,4 +1,5 @@
 DISCORD_TOKEN="DiscordBOTのトークン"
 GUILD_ID="コマンドを登録するサーバーのID (省略した際はグローバルコマンドとして登録)"
 
-DATABASE_URI="mongoDBに接続するためのURI"
+DATABASE_URL="Postgresqlに接続するためのURL"
+DEV_MODE=開発モードで起動する場合はtrue

--- a/src/constants/emojis.ts
+++ b/src/constants/emojis.ts
@@ -1,69 +1,136 @@
 import type { GuildFeature, UserFlagsString } from 'discord.js';
 
-export const white = {
-  addMark: '988439798324817930',
-  boost: '896591259886567434',
-  channel: '966588719635267624',
-  id: '1005688192818761748',
-  message: '966596708458983484',
-  moderator: '969148338597412884',
-  member: '1005688190931320922',
-  pencil: '988439788132646954',
-  removeMark: '989089271275204608',
-  role2: '1053347359695835146',
-  role: '966719258430160986',
-  schedule: '1014603109001085019',
-  timeOut: '1016740772340576306',
-  image: '1018167020824576132',
-  download: '1018760839743950909',
-  link: '1065688873281265674',
-  reply: '971069195343249458',
-  addLink: '1066923392172818502',
-  addSelectRole: '1066923389245202453',
-  addButtonRole: '1066923387563290784',
-  setting: '966588719635263539',
-  home: '971389898076598322',
-} as const;
+export const white = process.env.DEV_MODE
+  ? {
+      addCircle: '1371021096568098857',
+      minusCircle: '1371021552136491029',
+      boost: '1371024758816112691',
+      channel: '1371023506493411328',
+      id: '1371024815934410782',
+      message: '1371024863443157012',
+      member: '1371024961317376000',
+      pencil: '1371025048688660571',
+      role: '1371025185666236496',
+      role2: '1371025351559610378',
+      schedule: '1371025457818112011',
+      image: '1371025624264605836',
+      download: '1371025673807986728',
+      link: '1371025713968189451',
+      reply: '1371026038922149908',
+      addComponent: '1371026348776357888',
+      setting: '1371026130156388352',
+      home: '1371026222397526026',
+    }
+  : {
+      addCircle: '1371022342452547625',
+      minusCircle: '1371022880074235935',
+      boost: '1371026909575778414',
+      channel: '1371026945646661704',
+      id: '1371026989720535162',
+      message: '1371027147505795173',
+      member: '1371027018124230739',
+      pencil: '1371027309632421969',
+      role: '1371027335847084052',
+      role2: '1371027360089899099',
+      schedule: '1371027395615920129',
+      image: '1371027467648761896',
+      download: '1371027504684466306',
+      link: '1371027534556430387',
+      reply: '1371027590025969695',
+      addComponent: '1371027626180739072',
+      setting: '1371027658787520583',
+      home: '1371027691708485652',
+    };
 
-export const gray = {
-  member: '1064889710843002991',
-  text: '1064889722796773376',
-  link: '1064889715863601192',
-  edit: '1064889719680401460',
-  channel: '1064889714139746304',
-  schedule: '966773928620064841',
-} as const;
+export const gray = process.env.DEV_MODE
+  ? {
+      member: '1371033101802934323',
+      text: '1371033150599331860',
+      link: '1371033190977769502',
+      edit: '1371033237438201987',
+      channel: '1371033319780782201',
+      schedule: '1371033373929115718',
+    }
+  : {
+      member: '1371033413368283219',
+      text: '1371033440027279400',
+      link: '1371033490891608146',
+      edit: '1371033515516493925',
+      channel: '1371033547787341905',
+      schedule: '1371033574366515250',
+    };
 
-export const blurple = {
-  member: '1064891793642098708',
-  text: '1064891791385571359',
-  admin: '1064924738960490546',
-} as const;
+export const blurple = process.env.DEV_MODE
+  ? {
+      member: '1371035046424739851',
+      text: '1371035177266057276',
+      admin: '1371035255867179058',
+    }
+  : {
+      member: '1371035329980792852',
+      text: '1371035367209173052',
+      admin: '1371035400902017136',
+    };
 
-export const space = '1064892783804043344';
+export const red = process.env.DEV_MODE
+  ? {
+      flag: '1371028192428560414',
+      timeout: '1371028258115682357',
+    }
+  : {
+      flag: '1371028135767834745',
+      timeout: '1371028535837327510',
+    };
 
-export const userFlag: Partial<Record<UserFlagsString, string>> = {
-  Staff: '966753508739121222',
-  Partner: '966753508860768357',
-  CertifiedModerator: '959536411894243378',
-  Hypesquad: '966753508961439745',
-  HypeSquadOnlineHouse1: '966753508843978872',
-  HypeSquadOnlineHouse2: '966753508927889479',
-  HypeSquadOnlineHouse3: '966753508776890459',
-  BugHunterLevel1: '966753508848205925',
-  BugHunterLevel2: '966753508755898410',
-  ActiveDeveloper: '1040345950318768218',
-  VerifiedDeveloper: '966753508705583174',
-  PremiumEarlySupporter: '966753508751736892',
-};
+export const space = process.env.DEV_MODE
+  ? '1371031893574815817'
+  : '1371031995525627964';
 
-export const guildFeatures: Partial<Record<GuildFeature, string>> = {
-  PARTNERED: '982512900432351262',
-  VERIFIED: '982512902042955806',
-  DISCOVERABLE: '1087358252691496960',
-};
+export const userFlag: Partial<Record<UserFlagsString, string>> = process.env
+  .DEV_MODE
+  ? {
+      Staff: '1371039760851800074',
+      Partner: '1371039984919908352',
+      CertifiedModerator: '1371040015144063006',
+      Hypesquad: '1371040056298569798',
+      HypeSquadOnlineHouse1: '1371040088397578300',
+      HypeSquadOnlineHouse2: '1371040128382013550',
+      HypeSquadOnlineHouse3: '1371040153186996304',
+      BugHunterLevel1: '1371040180722470932',
+      BugHunterLevel2: '1371040203527032913',
+      ActiveDeveloper: '1371040228093067304',
+      VerifiedDeveloper: '1371040261085462578',
+      PremiumEarlySupporter: '1371040283684241488',
+    }
+  : {
+      Staff: '1371042510578651236',
+      Partner: '1371042562399408128',
+      CertifiedModerator: '1371042606552977439',
+      Hypesquad: '1371042658822389861',
+      HypeSquadOnlineHouse1: '1371042698538123396',
+      HypeSquadOnlineHouse2: '1371042732381835325',
+      HypeSquadOnlineHouse3: '1371042769430122626',
+      BugHunterLevel1: '1371042870806446130',
+      BugHunterLevel2: '1371042929480831026',
+      ActiveDeveloper: '1371042963031068793',
+      VerifiedDeveloper: '1371042989358448703',
+      PremiumEarlySupporter: '1371043047965720576',
+    };
 
-const colorEmojis = { white, gray, blurple };
+export const guildFeatures: Partial<Record<GuildFeature, string>> = process.env
+  .DEV_MODE
+  ? {
+      PARTNERED: '1371043946813329438',
+      VERIFIED: '1371043994859208734',
+      DISCOVERABLE: '1371044016337977384',
+    }
+  : {
+      PARTNERED: '1371044114149281822',
+      VERIFIED: '1371044139508043867',
+      DISCOVERABLE: '1371044171065983028',
+    };
+
+const colorEmojis = { white, gray, blurple, red };
 type ColorEmojis = typeof colorEmojis;
 export type Emojis<
   T extends ColorEmojis[keyof ColorEmojis] = ColorEmojis[keyof ColorEmojis],
@@ -79,7 +146,8 @@ type HasColor<
 export type EmojiColors<E extends Emojis> =
   | HasColor<E, 'white'>
   | HasColor<E, 'gray'>
-  | HasColor<E, 'blurple'>;
+  | HasColor<E, 'blurple'>
+  | HasColor<E, 'red'>;
 
 export function getColorEmoji<E extends Emojis>(
   emoji: E,

--- a/src/constants/emojis.ts
+++ b/src/constants/emojis.ts
@@ -146,8 +146,7 @@ type HasColor<
 export type EmojiColors<E extends Emojis> =
   | HasColor<E, 'white'>
   | HasColor<E, 'gray'>
-  | HasColor<E, 'blurple'>
-  | HasColor<E, 'red'>;
+  | HasColor<E, 'blurple'>;
 
 export function getColorEmoji<E extends Emojis>(
   emoji: E,

--- a/src/env.d.ts
+++ b/src/env.d.ts
@@ -5,6 +5,7 @@ declare module 'node:process' {
         readonly DISCORD_TOKEN: string;
         readonly GUILD_ID?: string;
         readonly DATABASE_URL: string;
+        readonly DEV_MODE?: boolean;
       }
     }
   }

--- a/src/interactions/embed/context.ts
+++ b/src/interactions/embed/context.ts
@@ -64,17 +64,17 @@ const context = new MessageContext(
               {
                 label: 'ロール付与(セレクトメニュー)を追加',
                 value: 'addRoleSelect',
-                emoji: white.role2,
+                emoji: white.addComponent,
               },
               {
                 label: 'ロール付与(ボタン)を追加',
                 value: 'addRoleButton',
-                emoji: white.role2,
+                emoji: white.addComponent,
               },
               {
                 label: 'URLボタンを追加',
                 value: 'addUrlButton',
-                emoji: white.link,
+                emoji: white.addComponent,
               },
               { label: 'コンポーネントの削除', value: 'delete', emoji: '🗑' },
             ),
@@ -151,7 +151,7 @@ const select = new SelectMenu(
             new ButtonBuilder()
               .setCustomId('nonick-js:embedMaker-roleButton-send')
               .setLabel('ボタンを作成')
-              .setEmoji(white.addMark)
+              .setEmoji(white.addCircle)
               .setStyle(ButtonStyle.Secondary),
             new ButtonBuilder()
               .setCustomId('nonick-js:embedMaker-roleButton-changeStyle')
@@ -175,7 +175,7 @@ const select = new SelectMenu(
             new ButtonBuilder()
               .setCustomId('nonick-js:embedMaker-linkButton-send')
               .setLabel('ボタンを作成')
-              .setEmoji(white.addMark)
+              .setEmoji(white.addCircle)
               .setStyle(ButtonStyle.Secondary),
           ),
         ],

--- a/src/interactions/embed/embed/_function.ts
+++ b/src/interactions/embed/embed/_function.ts
@@ -48,13 +48,13 @@ export function getBaseEmbedMakerButtons(embed: APIEmbed | Embed) {
       new ButtonBuilder()
         .setCustomId('nonick-js:embedMaker-addField')
         .setLabel('フィールド')
-        .setEmoji(white.addMark)
+        .setEmoji(white.addCircle)
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(embed.fields?.length === 25),
       new ButtonBuilder()
         .setCustomId('nonick-js:embedMaker-removeField')
         .setLabel('フィールド')
-        .setEmoji(white.removeMark)
+        .setEmoji(white.minusCircle)
         .setStyle(ButtonStyle.Secondary)
         .setDisabled(!embed.fields?.length),
       new ButtonBuilder()

--- a/src/interactions/embed/roleSelect/_function.ts
+++ b/src/interactions/embed/roleSelect/_function.ts
@@ -12,12 +12,12 @@ export function getRoleSelectMakerButtons(
   return new ActionRowBuilder<ButtonBuilder>().setComponents(
     new ButtonBuilder()
       .setCustomId('nonick-js:embedMaker-selectRole-addRole')
-      .setEmoji(white.addMark)
+      .setEmoji(white.addCircle)
       .setStyle(ButtonStyle.Secondary)
       .setDisabled(selectMenu?.options?.length === 25),
     new ButtonBuilder()
       .setCustomId('nonick-js:embedMaker-selectRole-removeRole')
-      .setEmoji(white.removeMark)
+      .setEmoji(white.minusCircle)
       .setStyle(ButtonStyle.Secondary)
       .setDisabled(!selectMenu?.options?.length),
     new ButtonBuilder()


### PR DESCRIPTION
* 開発モードを示す新しい環境変数を導入
* 絵文字の保存先をサーバーからボットに変更 (`DEV_MODE`で使用する絵文字IDを切り替え可能)