### PR TITLE
hotfix: 認証パネル関連のファイルのインポートが相対パスではなく絶対パスになっていた問題を修正

### DIFF
--- a/biome.json
+++ b/biome.json
@@ -8,7 +8,7 @@
   },
   "linter": {
     "enabled": true,
-    "ignore": [".github", ".vscode", ".next", "node_modules"],
+    "ignore": [".github", ".vscode", ".next", "node_modules", "dist"],
     "rules": {
       "recommended": true,
       "correctness": {
@@ -20,7 +20,7 @@
   },
   "formatter": {
     "enabled": true,
-    "ignore": [".github", ".vscode", ".next", "node_modules"],
+    "ignore": [".github", ".vscode", ".next", "node_modules", "dist"],
     "formatWithErrors": true,
     "indentStyle": "space"
   },

--- a/src/interactions/create/verify/legacy-interaction.ts
+++ b/src/interactions/create/verify/legacy-interaction.ts
@@ -1,9 +1,6 @@
 import { Button } from '@akki256/discord-interaction';
 import { GuildMemberRoleManager, inlineCode } from 'discord.js';
-import {
-  verifyForButtonCaptcha,
-  verifyForImageCaptcha,
-} from 'interactions/create/verify/_function';
+import { verifyForButtonCaptcha, verifyForImageCaptcha } from './_function';
 
 const verifyButton = new Button(
   {


### PR DESCRIPTION
### 問題
* 従来の認証パネルを使用することができない
* 「メッセージを通報」等、一部のインタラクションコマンドが使用できない

### 原因
* `src/interactions/create/verify/legacy-interactions.ts`内の`verifyForbuttonCaptcha`および`verifyForImageCaptcha`のインポートが相対パスではなく絶対パスで行われていた
* この影響により、`legacy-interactions.ts`より後に読み込まれるファイルが正しく読み込まれず、一部のインタラクションコマンドが使用できなかった